### PR TITLE
Week3: Adding query categorization

### DIFF
--- a/utilities/query.py
+++ b/utilities/query.py
@@ -218,7 +218,9 @@ def get_categories(query):
     categories, probs = model.predict(query, k=5)
     threshold = 0.3
     categories = [c.replace("__label__", "") for c in categories]
-    return [c for i, c in enumerate(categories) if probs[i] >= threshold]
+    categories_filtered = [c for i, c in enumerate(categories) if probs[i] >= threshold]
+    print("Inferred categories:", categories_filtered)
+    return categories_filtered
 
 
 def search(client, user_query, index="bbuy_products", sort="_score", sortDir="desc", use_synonyms=False):

--- a/utilities/query.py
+++ b/utilities/query.py
@@ -56,7 +56,7 @@ def create_prior_queries(doc_ids, doc_id_weights,
 # Hardcoded query here.  Better to use search templates or other query config.
 def create_query(user_query, click_prior_query, filters, sort="_score", sortDir="desc", size=10, source=None, categories=(), use_synonyms=False):
     filters = [] if filters is None else []
-    if not args.boost_queries:
+    if args.filter_categories:
         filters.append({
             "terms": {
                 "categoryPathIds.keyword": categories
@@ -111,7 +111,7 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
             }
         }
     ]
-    if args.boost_queries:
+    if args.boost_categories:
         should_clauses.append({
             "terms": {
                 "categoryPathIds.keyword": categories,
@@ -251,9 +251,12 @@ if __name__ == "__main__":
     general.add_argument('--synonyms',
                          action='store_true',
                          help='Whether to use the synonyms field for search.')
-    general.add_argument("--boost_queries", 
+    general.add_argument("--filter_categories", 
                          action="store_true", 
-                         help="Whether to use inferred query categories for boosting (true)/filtering (false)")                         
+                         help="Whether to use inferred query categories for filtering.")                                
+    general.add_argument("--boost_categories", 
+                         action="store_true", 
+                         help="Whether to use inferred query categories for boosting.")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
1. For query classification:
    1. How many unique categories did you see in your rolled up training data when you set the minimum number of queries per category to 1000? To 10000?
      * Initially, following the instructions in the assignment, I got 388 categories.
      * I made a slight modification based on a discussion during the project walkthrough today where I started rolling up from the leaf categories upwards and finally got 406 categories.
    2. What were the best values you achieved for R@1, R@3, and R@5? You should have tried at least a few different models, varying the minimum number of queries per category, as well as trying different fastText parameters or query normalization. Report at least 2 of your runs.
      * Initial runs based on 388 categories. R@1: 0.6 R@2: 0.65, R@3: 0.71
      * Best values based on 406 categories (-lr 0.5 -epoch 10 -wordNgrams 3): R@1: 0.66, R@2: 0.79, R@3: 0.85

2. For integrating query classification with search:
     1. Give 2 or 3 examples of queries where you saw a dramatic positive change in the results because of filtering. Make sure to include the classifier output for those queries.
       * Queries like `bag` gave better results with query filtering since it defaulted to notebook bags which I guess would be the predominant category. Without filtering, there was more diversity with camera bags being higher ranked.
     2. Give 2 or 3 examples of queries where filtering hurt the results, either because the classifier was wrong or for some other reason. Again, include the classifier output for those queries.
       * Queries like `cartridge`, `holidays` didn't yield any results as the categories passed the threshold were either empty or Movies. Boosting the categories yielded better results here.